### PR TITLE
Implement context hooks for top and side menus

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,12 +1,7 @@
 import React from 'react';
-import {
-    Home,
-    Activity,
-    Package,
-    Shield
-} from 'lucide-react';
-
+import { Home, Activity, Package, Shield, CheckCircle, Wrench, BarChart3 } from 'lucide-react';
 import { cn, focusRing } from '../utils/cn';
+import { useSidebarContext } from '../hooks/sidebar/useSidebarContext';
 
 /**
  * Sidebar Component - Desktop only navigation
@@ -22,43 +17,20 @@ import { cn, focusRing } from '../utils/cn';
 const Sidebar = ({
     onNavigate = () => { },
     currentPath = '/',
-    user = { role: 'admin' },
     className = '',
     ...props
 }) => {
-    // Simplified navigation items
-    const navItems = [
-        {
-            icon: Home,
-            label: 'Dashboard',
-            path: '/',
-            roles: ['admin', 'manager', 'operator', 'viewer']
-        },
-        {
-            icon: Activity,
-            label: 'Production',
-            path: '/production',
-            badge: 'Live',
-            roles: ['admin', 'manager', 'operator']
-        },
-        {
-            icon: Package,
-            label: 'Inventory',
-            path: '/inventory',
-            roles: ['admin', 'manager', 'operator']
-        },
-        {
-            icon: Shield,
-            label: 'User Management',
-            path: '/admin/users',
-            roles: ['admin']
-        }
-    ];
+    const { navigationItems } = useSidebarContext();
 
-    // Filter navigation items by user role
-    const filteredNavItems = navItems.filter(item =>
-        user && item.roles.includes(user.role)
-    );
+    const iconMap = {
+        Home,
+        Activity,
+        Package,
+        Shield,
+        CheckCircle,
+        Wrench,
+        BarChart3
+    };
 
     // Handle navigation
     const handleNavigate = (path) => {
@@ -79,8 +51,8 @@ const Sidebar = ({
         >
             {/* Navigation Menu */}
             <nav className="p-4 space-y-2 flex-1 overflow-y-auto">
-                {filteredNavItems.map((item) => {
-                    const Icon = item.icon;
+                {navigationItems.map((item) => {
+                    const Icon = iconMap[item.icon] || Home;
                     const isActive = currentPath === item.path ||
                         (item.path !== '/' && currentPath.startsWith(item.path + '/'));
 

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useRef, useEffect } from 'react';
 import {
     Menu,
     Bell,
@@ -18,6 +18,8 @@ import {
 import Logo, { LogoVariants } from './Logo';
 import { cn, focusRing } from '../utils/cn';
 import { ROUTES, USER_ROLES } from '../constants';
+import { useTopbarContext } from '../hooks/topbar/useTopbarContext';
+import { useAuth } from '../auth/useAuth';
 
 /**
  * TopBar Component - Header with mobile navigation dropdown
@@ -32,7 +34,6 @@ import { ROUTES, USER_ROLES } from '../constants';
  */
 
 const TopBar = ({
-    user = { name: 'Tal Shafir', email: 'tal@dantech-energy.com', role: 'admin' },
     onLogout = () => { },
     onNavigate = () => { },
     currentPath = '/',
@@ -40,46 +41,23 @@ const TopBar = ({
     ...props
 }) => {
 
-    // State management
-    const [showUserDropdown, setShowUserDropdown] = useState(false);
-    const [showNotifications, setShowNotifications] = useState(false);
-    const [showSearch, setShowSearch] = useState(false);
-    const [showMobileMenu, setShowMobileMenu] = useState(false);
-    const [searchQuery, setSearchQuery] = useState('');
-    const [notifications] = useState([
-        { id: 1, title: 'Production Alert', message: 'Line A efficiency dropped to 89%', type: 'warning', time: '5m ago', read: false },
-        { id: 2, title: 'Maintenance Scheduled', message: 'Line B maintenance tomorrow 9:00 AM', type: 'info', time: '1h ago', read: false },
-        { id: 3, title: 'Quality Check Complete', message: 'Batch #2024-001 passed all tests', type: 'success', time: '2h ago', read: true }
-    ]);
+    const { user } = useAuth();
 
-    // Mobile navigation items
-    const mobileNavItems = [
-        {
-            icon: Home,
-            label: 'Dashboard',
-            path: '/',
-            roles: ['admin', 'manager', 'operator', 'viewer']
-        },
-        {
-            icon: Activity,
-            label: 'Production',
-            path: '/production',
-            badge: 'Live',
-            roles: ['admin', 'manager', 'operator']
-        },
-        {
-            icon: Package,
-            label: 'Inventory',
-            path: '/inventory',
-            roles: ['admin', 'manager', 'operator']
-        },
-        {
-            icon: Shield,
-            label: 'User Management',
-            path: '/admin/users',
-            roles: ['admin']
-        }
-    ].filter(item => user && item.roles.includes(user.role));
+    const {
+        showUserDropdown,
+        setShowUserDropdown,
+        showNotifications,
+        setShowNotifications,
+        showSearch,
+        setShowSearch,
+        showMobileMenu,
+        setShowMobileMenu,
+        searchQuery,
+        setSearchQuery,
+        mobileNavItems,
+        notifications,
+        unreadNotificationsCount
+    } = useTopbarContext();
 
     // Get current page info
     const currentPage = mobileNavItems.find(item =>
@@ -149,9 +127,6 @@ const TopBar = ({
             .toUpperCase()
             .slice(0, 2);
     };
-
-    // Get notification badge count
-    const unreadNotificationsCount = notifications.filter(n => !n.read).length;
 
     return (
         <header

--- a/src/hooks/topbar/TopbarContext.js
+++ b/src/hooks/topbar/TopbarContext.js
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export const TopbarContext = createContext(null);

--- a/src/hooks/topbar/TopbarProvider.jsx
+++ b/src/hooks/topbar/TopbarProvider.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { TopbarContext } from './TopbarContext';
+import { useTopbar } from './useTopbar';
+
+export const TopbarProvider = ({ children }) => {
+  const topbarState = useTopbar();
+  return (
+    <TopbarContext.Provider value={topbarState}>
+      {children}
+    </TopbarContext.Provider>
+  );
+};

--- a/src/hooks/topbar/useTopbar.js
+++ b/src/hooks/topbar/useTopbar.js
@@ -1,0 +1,49 @@
+import { useState, useMemo } from 'react';
+import { Home, Activity, Package, Shield } from 'lucide-react';
+import { useAuth } from '../../auth/useAuth';
+
+export const useTopbar = () => {
+  const { user } = useAuth();
+
+  const [showUserDropdown, setShowUserDropdown] = useState(false);
+  const [showNotifications, setShowNotifications] = useState(false);
+  const [showSearch, setShowSearch] = useState(false);
+  const [showMobileMenu, setShowMobileMenu] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [notifications] = useState([
+    { id: 1, title: 'Production Alert', message: 'Line A efficiency dropped to 89%', type: 'warning', time: '5m ago', read: false },
+    { id: 2, title: 'Maintenance Scheduled', message: 'Line B maintenance tomorrow 9:00 AM', type: 'info', time: '1h ago', read: false },
+    { id: 3, title: 'Quality Check Complete', message: 'Batch #2024-001 passed all tests', type: 'success', time: '2h ago', read: true }
+  ]);
+
+  const mobileNavItems = useMemo(() => {
+    const items = [
+      { icon: Home, label: 'Dashboard', path: '/', roles: ['admin', 'manager', 'operator', 'viewer'] },
+      { icon: Activity, label: 'Production', path: '/production', badge: 'Live', roles: ['admin', 'manager', 'operator'] },
+      { icon: Package, label: 'Inventory', path: '/inventory', roles: ['admin', 'manager', 'operator'] },
+      { icon: Shield, label: 'User Management', path: '/admin/users', roles: ['admin'] }
+    ];
+    return user ? items.filter(item => item.roles.includes(user.role)) : [];
+  }, [user]);
+
+  const unreadNotificationsCount = useMemo(
+    () => notifications.filter(n => !n.read).length,
+    [notifications]
+  );
+
+  return {
+    showUserDropdown,
+    setShowUserDropdown,
+    showNotifications,
+    setShowNotifications,
+    showSearch,
+    setShowSearch,
+    showMobileMenu,
+    setShowMobileMenu,
+    searchQuery,
+    setSearchQuery,
+    mobileNavItems,
+    notifications,
+    unreadNotificationsCount
+  };
+};

--- a/src/hooks/topbar/useTopbarContext.js
+++ b/src/hooks/topbar/useTopbarContext.js
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { TopbarContext } from './TopbarContext';
+
+export const useTopbarContext = () => {
+  const context = useContext(TopbarContext);
+  if (!context) {
+    throw new Error('useTopbarContext must be used within a TopbarProvider');
+  }
+  return context;
+};

--- a/src/layouts/DashboardLayout.jsx
+++ b/src/layouts/DashboardLayout.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import TopBar from '../components/TopBar';
 import Sidebar from '../components/Sidebar';
 import { cn } from '../utils/cn';
+import { SidebarProvider } from '../hooks/sidebar/SidebarProvider';
+import { TopbarProvider } from '../hooks/topbar/TopbarProvider';
 
 /**
  * DashboardLayout Component - Mobile-first responsive layout
@@ -15,7 +17,6 @@ import { cn } from '../utils/cn';
 
 const DashboardLayout = ({
     children,
-    user = { name: 'Tal Shafir', email: 'tal@dantech-energy.com', role: 'admin' },
     onLogout = () => { },
     onNavigate = () => { },
     currentPath = '/',
@@ -25,36 +26,38 @@ const DashboardLayout = ({
 
     return (
         <div className={cn('min-h-screen bg-gray-50', className)} {...props}>
-            {/* TopBar - Always at the top with mobile navigation */}
-            <TopBar
-                user={user}
-                onLogout={onLogout}
-                onNavigate={onNavigate}
-                currentPath={currentPath}
-            />
+            <TopbarProvider>
+                <SidebarProvider>
+                    {/* TopBar - Always at the top with mobile navigation */}
+                    <TopBar
+                        onLogout={onLogout}
+                        onNavigate={onNavigate}
+                        currentPath={currentPath}
+                    />
 
-            {/* Sidebar - Desktop only (completely hidden on mobile) */}
-            <Sidebar
-                onNavigate={onNavigate}
-                currentPath={currentPath}
-                user={user}
-            />
+                    {/* Sidebar - Desktop only (completely hidden on mobile) */}
+                    <Sidebar
+                        onNavigate={onNavigate}
+                        currentPath={currentPath}
+                    />
 
-            {/* Main Content Area */}
-            <main
-                className={cn(
-                    'transition-all duration-300',
-                    'min-h-[calc(100vh-73px)]', // Full height minus TopBar
-                    // Desktop: add left margin for sidebar, Mobile: full width
-                    'lg:ml-64'
-                )}
-            >
-                {/* Content Wrapper with Proper Padding */}
-                <div className="p-6 max-w-7xl mx-auto">
-                    {/* Render page content */}
-                    {children}
-                </div>
-            </main>
+                    {/* Main Content Area */}
+                    <main
+                        className={cn(
+                            'transition-all duration-300',
+                            'min-h-[calc(100vh-73px)]', // Full height minus TopBar
+                            // Desktop: add left margin for sidebar, Mobile: full width
+                            'lg:ml-64'
+                        )}
+                    >
+                        {/* Content Wrapper with Proper Padding */}
+                        <div className="p-6 max-w-7xl mx-auto">
+                            {/* Render page content */}
+                            {children}
+                        </div>
+                    </main>
+                </SidebarProvider>
+            </TopbarProvider>
         </div>
     );
 };


### PR DESCRIPTION
## Summary
- add `Topbar` context, provider and hook
- refactor `TopBar` component to use new context and auth hook
- refactor `Sidebar` to read navigation items from sidebar hook
- wrap dashboard layout with providers

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688722ddea4c83218aa5560236c4c7e6