### PR TITLE
Update frontend for new backend API

### DIFF
--- a/src/api/users.js
+++ b/src/api/users.js
@@ -1,0 +1,35 @@
+import { API_ENDPOINTS } from '../constants';
+
+const BASE_URL = API_ENDPOINTS.BASE_URL;
+
+async function request(path, options = {}) {
+  const headers = { 'Content-Type': 'application/json', ...(options.headers || {}) };
+  const token = localStorage.getItem('auth_token');
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+
+  const res = await fetch(`${BASE_URL}${path}`, {
+    credentials: 'include',
+    ...options,
+    headers,
+  });
+
+  if (!res.ok) {
+    let error;
+    try {
+      const data = await res.json();
+      error = data.error || res.statusText;
+    } catch {
+      error = res.statusText;
+    }
+    throw new Error(error);
+  }
+  if (res.status === 204) return null;
+  return res.json();
+}
+
+export default {
+  get: (path) => request(path),
+  post: (path, data) => request(path, { method: 'POST', body: JSON.stringify(data) }),
+  put: (path, data) => request(path, { method: 'PUT', body: JSON.stringify(data) }),
+  delete: (path) => request(path, { method: 'DELETE' }),
+};

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -119,8 +119,9 @@ const TopBar = ({
 
     // Get user initials for avatar
     const getUserInitials = () => {
-        if (!user?.name) return 'U';
-        return user.name
+        if (user?.avatar_initials) return user.avatar_initials;
+        if (!user?.full_name) return 'U';
+        return user.full_name
             .split(' ')
             .map(n => n[0])
             .join('')
@@ -360,8 +361,8 @@ const TopBar = ({
 
                                 {/* User Info */}
                                 <div className="px-4 py-3 border-b border-gray-100 bg-brand-gradient bg-opacity-5">
-                                    <div className="font-medium text-brand-349">{user?.name || 'User'}</div>
-                                    <div className="text-sm text-gray-500">{user?.email}</div>
+                                    <div className="font-medium text-brand-349">{user?.full_name || 'User'}</div>
+                                    <div className="text-sm text-gray-500">{user?.username}</div>
                                     <div className="text-xs text-brand-361 font-medium mt-1 capitalize">
                                         {user?.role} Access
                                     </div>

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -313,45 +313,43 @@ export const PRIORITY_LEVELS = {
 // =====================================================
 
 export const API_ENDPOINTS = {
-  BASE_URL: import.meta.env.VITE_API_URL || 'http://localhost:3001/api',
-  
+  BASE_URL: import.meta.env.VITE_API_URL || 'http://localhost:5000/api',
+
   // Authentication
   AUTH: {
-    LOGIN: '/auth/login',
-    LOGOUT: '/auth/logout',
-    REFRESH: '/auth/refresh',
-    PROFILE: '/auth/profile'
+    LOGIN: '/login',
+    LOGOUT: '/logout',
+    CURRENT_USER: '/current-user'
   },
-  
-  // Production
-  PRODUCTION: {
-    LINES: '/production/lines',
-    ORDERS: '/production/orders',
-    METRICS: '/production/metrics',
-    STATUS: '/production/status'
+
+  // Projects & dashboard
+  PROJECTS: '/projects',
+  PROJECT_SUBITEMS: (id) => `/project/${id}/subitems`,
+  SUBITEM_ASSETS: (projectId, subitemId) =>
+    `/project/${projectId}/subitem/${subitemId}/assets`,
+
+  // Workflow
+  SCAN_BATTERY: '/scan-battery',
+  STATION_CHECKLIST: (station) => `/station/${station}/checklist`,
+  COMPLETE_STATION: '/complete-station',
+
+  // Failures & files
+  REPORT_FAILURE: '/report-failure',
+  UPLOAD_FILE: '/upload-file',
+
+  // Admin
+  ADMIN: {
+    USERS: '/admin/users',
+    USER: (id) => `/admin/users/${id}`,
+    IMPERSONATE: (id) => `/admin/impersonate/${id}`,
+    STOP_IMPERSONATION: '/admin/stop-impersonation',
+    ANALYTICS: '/admin/analytics',
+    RELOAD_USERS: '/admin/reload-users'
   },
-  
-  // Analytics
-  ANALYTICS: {
-    PERFORMANCE: '/analytics/performance',
-    EFFICIENCY: '/analytics/efficiency',
-    ENERGY: '/analytics/energy'
-  },
-  
-  // Users & Admin
-  USERS: {
-    LIST: '/users',
-    CREATE: '/users',
-    UPDATE: '/users/:id',
-    DELETE: '/users/:id'
-  },
-  
+
   // System
-  SYSTEM: {
-    HEALTH: '/system/health',
-    BACKUP: '/system/backup',
-    LOGS: '/system/logs'
-  }
+  HEALTH: '/health',
+  CLEAR_CACHE: '/system/cache/clear'
 };
 
 export const REQUEST_TIMEOUT = 30000; // 30 seconds

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -6,7 +6,7 @@ import Logo from "../components/Logo";
 
 export default function LoginPage() {
     const { user, login } = useAuth();
-    const [email, setEmail] = useState("");
+    const [username, setUsername] = useState("");
     const [password, setPassword] = useState("");
     const [showPassword, setShowPassword] = useState(false);
     const [error, setError] = useState(null);
@@ -19,9 +19,9 @@ export default function LoginPage() {
         setLoading(true);
         setError(null);
         try {
-            await login(email, password);
+            await login(username, password);
         } catch (err) {
-            setError("Invalid credentials");
+            setError(err.message || "Invalid credentials");
             setLoading(false);
         }
     };
@@ -39,11 +39,11 @@ export default function LoginPage() {
 
                 <div className="space-y-4">
                     <input
-                        type="email"
+                        type="text"
                         className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-361/40 focus:border-brand-361 transition-colors"
-                        placeholder="Email"
-                        value={email}
-                        onChange={(e) => setEmail(e.target.value)}
+                        placeholder="Username"
+                        value={username}
+                        onChange={(e) => setUsername(e.target.value)}
                         disabled={loading}
                         required
                     />


### PR DESCRIPTION
## Summary
- add fetch-based api client
- wire up AuthProvider to real backend endpoints
- update login form to use username/password
- show new user fields in TopBar
- replace API endpoint definitions for portal backend
- rename api client file

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6887307ba31c8321a2580c9ebd185e92