### PR TITLE
Update frontend for new backend API

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Development login bypass
+
+Set the environment variable `VITE_AUTH_BYPASS=true` to bypass the API-based authentication during local development. When enabled, you can sign in with username `admin` and password `12345` without the backend running.

--- a/src/api/users.js
+++ b/src/api/users.js
@@ -1,0 +1,35 @@
+import { API_ENDPOINTS } from '../constants';
+
+const BASE_URL = API_ENDPOINTS.BASE_URL;
+
+async function request(path, options = {}) {
+  const headers = { 'Content-Type': 'application/json', ...(options.headers || {}) };
+  const token = localStorage.getItem('auth_token');
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+
+  const res = await fetch(`${BASE_URL}${path}`, {
+    credentials: 'include',
+    ...options,
+    headers,
+  });
+
+  if (!res.ok) {
+    let error;
+    try {
+      const data = await res.json();
+      error = data.error || res.statusText;
+    } catch {
+      error = res.statusText;
+    }
+    throw new Error(error);
+  }
+  if (res.status === 204) return null;
+  return res.json();
+}
+
+export default {
+  get: (path) => request(path),
+  post: (path, data) => request(path, { method: 'POST', body: JSON.stringify(data) }),
+  put: (path, data) => request(path, { method: 'PUT', body: JSON.stringify(data) }),
+  delete: (path) => request(path, { method: 'DELETE' }),
+};

--- a/src/auth/AuthProvider.jsx
+++ b/src/auth/AuthProvider.jsx
@@ -1,38 +1,119 @@
-import React, { useState } from "react";
-import { AuthContext } from "./AuthContext";
+import React, { useEffect, useState } from 'react';
+import { AuthContext } from './AuthContext';
+import api from '../api/users';
+import { API_ENDPOINTS, AUTH_STORAGE_KEYS, FEATURES } from '../constants';
 
+/**
+ * AuthProvider handles user authentication state.
+ * It loads the current user on mount and exposes
+ * login and logout helpers to child components.
+ */
 export const AuthProvider = ({ children }) => {
-    // null | { email, role }
-    const [user, setUser] = useState(null);
-    const [loading, setLoading] = useState(false);
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
 
-    /**
-     * Dummy login – resolves if credentials match hard‑coded admin user.
-     * @param {string} email
-     * @param {string} password
-     */
-    const login = (email, password) => {
-        setLoading(true);
-        return new Promise((resolve, reject) => {
-            setTimeout(() => {
-                const ok = (email === "admin" || email === "admin@danenergy.com") && password === "12345";
-                if (ok) {
-                    setUser({ email, role: "admin" });
-                    setLoading(false);
-                    resolve();
-                } else {
-                    setLoading(false);
-                    reject(new Error("Invalid credentials"));
-                }
-            }, 400); // small delay for UX
-        });
+  // ------------------------------------------------------------------
+  // Helpers
+  // ------------------------------------------------------------------
+
+  const loadBypassUser = () => {
+    const data = localStorage.getItem(AUTH_STORAGE_KEYS.USER);
+    if (!data) return null;
+    try {
+      return JSON.parse(data);
+    } catch {
+      return null;
+    }
+  };
+
+  const saveBypassUser = (data) => {
+    localStorage.setItem(AUTH_STORAGE_KEYS.USER, JSON.stringify(data));
+  };
+
+  const clearBypassUser = () => {
+    localStorage.removeItem(AUTH_STORAGE_KEYS.USER);
+  };
+
+  // ------------------------------------------------------------------
+  // Fetch current user on mount
+  // ------------------------------------------------------------------
+  useEffect(() => {
+    const init = async () => {
+      if (FEATURES.AUTH_BYPASS) {
+        const stored = loadBypassUser();
+        if (stored) setUser(stored);
+        setLoading(false);
+        return;
+      }
+      try {
+        const data = await api.get(API_ENDPOINTS.AUTH.CURRENT_USER);
+        setUser(data);
+      } catch {
+        setUser(null);
+      } finally {
+        setLoading(false);
+      }
     };
+    init();
+  }, []);
 
-    const logout = () => setUser(null);
+  // ------------------------------------------------------------------
+  // Login
+  // ------------------------------------------------------------------
+  const login = async (username, password) => {
+    setLoading(true);
 
-    return (
-        <AuthContext.Provider value={{ user, loading, login, logout }}>
-            {children}
-        </AuthContext.Provider>
-    );
+    if (FEATURES.AUTH_BYPASS) {
+      const ok =
+        username.trim().toLowerCase() === 'admin' && password.trim() === '12345';
+      if (!ok) {
+        setLoading(false);
+        throw new Error('Invalid credentials');
+      }
+      const bypassUser = {
+        id: 'local-admin',
+        username: 'admin',
+        full_name: 'Admin User',
+        role: 'admin',
+      };
+      setUser(bypassUser);
+      saveBypassUser(bypassUser);
+      setLoading(false);
+      return;
+    }
+
+    const { token, user: loggedIn } = await api.post(API_ENDPOINTS.AUTH.LOGIN, {
+      username,
+      password,
+    });
+
+    if (token) {
+      localStorage.setItem(AUTH_STORAGE_KEYS.TOKEN, token);
+    }
+
+    setUser(loggedIn);
+    setLoading(false);
+  };
+
+  // ------------------------------------------------------------------
+  // Logout
+  // ------------------------------------------------------------------
+  const logout = async () => {
+    if (FEATURES.AUTH_BYPASS) {
+      clearBypassUser();
+      setUser(null);
+      return;
+    }
+
+    try {
+      await api.post(API_ENDPOINTS.AUTH.LOGOUT);
+    } finally {
+      localStorage.removeItem(AUTH_STORAGE_KEYS.TOKEN);
+      setUser(null);
+    }
+  };
+
+  const value = { user, loading, login, logout };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };

--- a/src/auth/ProtectedRoute.jsx
+++ b/src/auth/ProtectedRoute.jsx
@@ -4,7 +4,11 @@ import { useAuth } from "./useAuth";
 
 export const ProtectedRoute = ({ roles }) => {
     const { user, loading } = useAuth();
-    if (loading) return null; // or loading splash
+    if (loading) {
+        return (
+            <div className="p-6 text-center text-brand-349">Loading…</div>
+        );
+    }
     if (!user) return <Navigate to="/login" replace />;
     if (roles && !roles.includes(user.role)) return <Navigate to="/" replace />;
     return <Outlet />;

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -119,8 +119,9 @@ const TopBar = ({
 
     // Get user initials for avatar
     const getUserInitials = () => {
-        if (!user?.name) return 'U';
-        return user.name
+        if (user?.avatar_initials) return user.avatar_initials;
+        if (!user?.full_name) return 'U';
+        return user.full_name
             .split(' ')
             .map(n => n[0])
             .join('')
@@ -360,8 +361,8 @@ const TopBar = ({
 
                                 {/* User Info */}
                                 <div className="px-4 py-3 border-b border-gray-100 bg-brand-gradient bg-opacity-5">
-                                    <div className="font-medium text-brand-349">{user?.name || 'User'}</div>
-                                    <div className="text-sm text-gray-500">{user?.email}</div>
+                                    <div className="font-medium text-brand-349">{user?.full_name || 'User'}</div>
+                                    <div className="text-sm text-gray-500">{user?.username}</div>
                                     <div className="text-xs text-brand-361 font-medium mt-1 capitalize">
                                         {user?.role} Access
                                     </div>

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -313,45 +313,43 @@ export const PRIORITY_LEVELS = {
 // =====================================================
 
 export const API_ENDPOINTS = {
-  BASE_URL: import.meta.env.VITE_API_URL || 'http://localhost:3001/api',
-  
+  BASE_URL: import.meta.env.VITE_API_URL || 'http://localhost:5000/api',
+
   // Authentication
   AUTH: {
-    LOGIN: '/auth/login',
-    LOGOUT: '/auth/logout',
-    REFRESH: '/auth/refresh',
-    PROFILE: '/auth/profile'
+    LOGIN: '/login',
+    LOGOUT: '/logout',
+    CURRENT_USER: '/current-user'
   },
-  
-  // Production
-  PRODUCTION: {
-    LINES: '/production/lines',
-    ORDERS: '/production/orders',
-    METRICS: '/production/metrics',
-    STATUS: '/production/status'
+
+  // Projects & dashboard
+  PROJECTS: '/projects',
+  PROJECT_SUBITEMS: (id) => `/project/${id}/subitems`,
+  SUBITEM_ASSETS: (projectId, subitemId) =>
+    `/project/${projectId}/subitem/${subitemId}/assets`,
+
+  // Workflow
+  SCAN_BATTERY: '/scan-battery',
+  STATION_CHECKLIST: (station) => `/station/${station}/checklist`,
+  COMPLETE_STATION: '/complete-station',
+
+  // Failures & files
+  REPORT_FAILURE: '/report-failure',
+  UPLOAD_FILE: '/upload-file',
+
+  // Admin
+  ADMIN: {
+    USERS: '/admin/users',
+    USER: (id) => `/admin/users/${id}`,
+    IMPERSONATE: (id) => `/admin/impersonate/${id}`,
+    STOP_IMPERSONATION: '/admin/stop-impersonation',
+    ANALYTICS: '/admin/analytics',
+    RELOAD_USERS: '/admin/reload-users'
   },
-  
-  // Analytics
-  ANALYTICS: {
-    PERFORMANCE: '/analytics/performance',
-    EFFICIENCY: '/analytics/efficiency',
-    ENERGY: '/analytics/energy'
-  },
-  
-  // Users & Admin
-  USERS: {
-    LIST: '/users',
-    CREATE: '/users',
-    UPDATE: '/users/:id',
-    DELETE: '/users/:id'
-  },
-  
+
   // System
-  SYSTEM: {
-    HEALTH: '/system/health',
-    BACKUP: '/system/backup',
-    LOGS: '/system/logs'
-  }
+  HEALTH: '/health',
+  CLEAR_CACHE: '/system/cache/clear'
 };
 
 export const REQUEST_TIMEOUT = 30000; // 30 seconds
@@ -446,7 +444,8 @@ export const FEATURES = {
   DARK_MODE: import.meta.env.VITE_FEATURE_DARK_MODE === 'true',
   ANALYTICS_EXPORT: import.meta.env.VITE_FEATURE_ANALYTICS_EXPORT === 'true',
   REAL_TIME_NOTIFICATIONS: import.meta.env.VITE_FEATURE_REAL_TIME === 'true',
-  ADVANCED_REPORTING: import.meta.env.VITE_FEATURE_ADVANCED_REPORTS === 'true'
+  ADVANCED_REPORTING: import.meta.env.VITE_FEATURE_ADVANCED_REPORTS === 'true',
+  AUTH_BYPASS: import.meta.env.VITE_AUTH_BYPASS === 'true'
 };
 
 // =====================================================

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -5,12 +5,20 @@ import { useAuth } from "../auth/useAuth";
 import Logo from "../components/Logo";
 
 export default function LoginPage() {
-    const { user, login } = useAuth();
-    const [email, setEmail] = useState("");
+    const { user, login, loading: authLoading } = useAuth();
+    const [username, setUsername] = useState("");
     const [password, setPassword] = useState("");
     const [showPassword, setShowPassword] = useState(false);
     const [error, setError] = useState(null);
     const [loading, setLoading] = useState(false);
+
+    if (authLoading) {
+        return (
+            <div className="flex items-center justify-center min-h-screen p-6">
+                <Loader2 className="animate-spin text-brand-349" />
+            </div>
+        );
+    }
 
     if (user) return <Navigate to="/" replace />;
 
@@ -19,9 +27,9 @@ export default function LoginPage() {
         setLoading(true);
         setError(null);
         try {
-            await login(email, password);
+            await login(username, password);
         } catch (err) {
-            setError("Invalid credentials");
+            setError(err.message || "Invalid credentials");
             setLoading(false);
         }
     };
@@ -39,11 +47,11 @@ export default function LoginPage() {
 
                 <div className="space-y-4">
                     <input
-                        type="email"
+                        type="text"
                         className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-361/40 focus:border-brand-361 transition-colors"
-                        placeholder="Email"
-                        value={email}
-                        onChange={(e) => setEmail(e.target.value)}
+                        placeholder="Username"
+                        value={username}
+                        onChange={(e) => setUsername(e.target.value)}
                         disabled={loading}
                         required
                     />


### PR DESCRIPTION
## Summary
- add fetch-based api client
- wire up AuthProvider to real backend endpoints
- update login form to use username/password
- show new user fields in TopBar
- replace API endpoint definitions for portal backend
- rename api client file
- add local login bypass
- make bypass check case-insensitive
- show a loader while auth state is loading
- rewrite AuthProvider from scratch

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6887307ba31c8321a2580c9ebd185e92