### PR TITLE
Add production worker workflow

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,12 +2,14 @@ import React, { Suspense, lazy } from "react";
 import { Route, Routes } from "react-router-dom";
 import { ProtectedRoute } from "./auth/ProtectedRoute";
 import DashboardLayout from "./layouts/DashboardLayout";
+import WorkerLayout from "./layouts/WorkerLayout";
 import LoginPage from "./pages/LoginPage";
 import HomePage from "./pages/HomePage";
 import NotFoundPage from "./pages/NotFoundPage";
 
 // Lazy‑loaded feature modules
 const ProductionPage = lazy(() => import("./pages/Production/ProductionPage"));
+const WorkerPage = lazy(() => import("./pages/ProductionWorker/WorkerPage"));
 const UsersPage = lazy(() => import("./pages/admin/UsersPage"));
 
 export default function App() {
@@ -25,6 +27,11 @@ export default function App() {
             {/* Admin‑only subsection */}
             <Route element={<ProtectedRoute roles={["admin"]} />}>
               <Route path="admin" element={<UsersPage />} />
+            </Route>
+          </Route>
+          <Route element={<ProtectedRoute roles={["pworker"]} />}> 
+            <Route element={<WorkerLayout />}>
+              <Route path="worker" element={<WorkerPage />} />
             </Route>
           </Route>
         </Route>

--- a/src/auth/AuthProvider.jsx
+++ b/src/auth/AuthProvider.jsx
@@ -68,18 +68,27 @@ export const AuthProvider = ({ children }) => {
     setLoading(true);
 
     if (FEATURES.AUTH_BYPASS) {
-      const ok =
-        username.trim().toLowerCase() === 'admin' && password.trim() === '12345';
-      if (!ok) {
+      let bypassUser = null;
+      const u = username.trim().toLowerCase();
+      if (u === 'admin' && password.trim() === '12345') {
+        bypassUser = {
+          id: 'local-admin',
+          username: 'admin',
+          full_name: 'Admin User',
+          role: 'admin',
+        };
+      } else if (u === 'pworker' && password.trim() === 'worker') {
+        bypassUser = {
+          id: 'local-pworker',
+          username: 'pworker',
+          full_name: 'Production Worker',
+          role: 'pworker',
+        };
+      }
+      if (!bypassUser) {
         setLoading(false);
         throw new Error('Invalid credentials');
       }
-      const bypassUser = {
-        id: 'local-admin',
-        username: 'admin',
-        full_name: 'Admin User',
-        role: 'admin',
-      };
       setUser(bypassUser);
       saveBypassUser(bypassUser);
       setLoading(false);

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -28,6 +28,7 @@ export const USER_ROLES = {
   ADMIN: 'admin',
   MANAGER: 'manager',
   OPERATOR: 'operator',
+  PWORKER: 'pworker',
   VIEWER: 'viewer'
 };
 
@@ -55,6 +56,9 @@ export const ROLE_PERMISSIONS = {
     'analytics.basic',
     'inventory.update'
   ],
+  [USER_ROLES.PWORKER]: [
+    'production.worker'
+  ],
   [USER_ROLES.VIEWER]: [
     'analytics.basic',
     'reports.view',
@@ -77,6 +81,7 @@ export const ROUTES = {
   HOME: '/',
   LOGIN: '/login',
   DASHBOARD: '/dashboard',
+  WORKER: '/worker',
   
   // Production
   PRODUCTION: '/production',
@@ -243,6 +248,16 @@ export const PRODUCTION_LINES = {
   QUALITY_CONTROL: 'quality_control',
   PACKAGING: 'packaging'
 };
+
+export const PRODUCTION_STATIONS = {
+  INITIAL_ASSEMBLY: 'Initial Assembly',
+  WELDING: 'Welding',
+  SOLDERING: 'Soldering',
+  FIRMWARE_VALIDATION: 'Firmware & Validation',
+  FINAL_ASSEMBLY: 'Final Assembly'
+};
+
+export const STATION_STORAGE_KEY = 'dantech_last_station';
 
 export const WORKSPACES = [
   {
@@ -461,6 +476,8 @@ export default {
   PRODUCTION_STATUS,
   WORKSPACES,
   STATUS_TYPES,
+  PRODUCTION_STATIONS,
+  STATION_STORAGE_KEY,
   API_ENDPOINTS,
   THEME_CONFIG,
   ERROR_MESSAGES,

--- a/src/hooks/sidebar/useSidebar.js
+++ b/src/hooks/sidebar/useSidebar.js
@@ -101,6 +101,14 @@ export const useSidebar = ({
         badge: null
       },
       {
+        id: 'worker',
+        label: 'Worker',
+        path: '/worker',
+        icon: 'Activity',
+        roles: ['pworker'],
+        badge: null
+      },
+      {
         id: 'quality',
         label: 'Quality Control',
         path: '/quality',

--- a/src/hooks/topbar/useTopbar.js
+++ b/src/hooks/topbar/useTopbar.js
@@ -21,6 +21,7 @@ export const useTopbar = () => {
       { icon: Home, label: 'Dashboard', path: '/', roles: ['admin', 'manager', 'operator', 'viewer'] },
       { icon: Activity, label: 'Production', path: '/production', badge: 'Live', roles: ['admin', 'manager', 'operator'] },
       { icon: Package, label: 'Inventory', path: '/inventory', roles: ['admin', 'manager', 'operator'] },
+      { icon: Activity, label: 'Worker', path: '/worker', roles: ['pworker'] },
       { icon: Shield, label: 'User Management', path: '/admin/users', roles: ['admin'] }
     ];
     return user ? items.filter(item => item.roles.includes(user.role)) : [];

--- a/src/layouts/WorkerLayout.jsx
+++ b/src/layouts/WorkerLayout.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import TopBar from '../components/TopBar';
+import { cn } from '../utils/cn';
+import { TopbarProvider } from '../hooks/topbar/TopbarProvider';
+
+const WorkerLayout = ({
+  children,
+  onLogout = () => {},
+  onNavigate = () => {},
+  currentPath = '/',
+  className = '',
+  ...props
+}) => {
+  return (
+    <div className={cn('min-h-screen bg-gray-50', className)} {...props}>
+      <TopbarProvider>
+        <TopBar
+          onLogout={onLogout}
+          onNavigate={onNavigate}
+          currentPath={currentPath}
+        />
+        <main className="pt-[73px]">
+          <div className="p-6 max-w-4xl mx-auto">{children}</div>
+        </main>
+      </TopbarProvider>
+    </div>
+  );
+};
+
+export default WorkerLayout;

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,4 +1,11 @@
 import React from "react";
+import { Navigate } from "react-router-dom";
+import { useAuth } from "../auth/useAuth";
+
 export default function HomePage() {
-    return <div className="p-6 text-brand-349">Welcome to Dan‑Tech Portal 👋</div>;
+  const { user } = useAuth();
+  if (user?.role === 'pworker') {
+    return <Navigate to="/worker" replace />;
+  }
+  return <div className="p-6 text-brand-349">Welcome to Dan‑Tech Portal 👋</div>;
 }

--- a/src/pages/ProductionWorker/WorkerPage.jsx
+++ b/src/pages/ProductionWorker/WorkerPage.jsx
@@ -1,0 +1,100 @@
+import React, { useState, useRef, useEffect } from 'react';
+import {
+  PRODUCTION_STATIONS,
+  STATION_STORAGE_KEY
+} from '../../constants';
+
+const sampleProjects = [
+  { id: 'p1', name: 'Battery Pack A' },
+  { id: 'p2', name: 'Battery Pack B' }
+];
+
+export default function WorkerPage() {
+  const [station, setStation] = useState(
+    () => localStorage.getItem(STATION_STORAGE_KEY) || ''
+  );
+  const [project, setProject] = useState('');
+  const [serial, setSerial] = useState('');
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [project]);
+
+  const handleStationSelect = (e) => {
+    const value = e.target.value;
+    setStation(value);
+    localStorage.setItem(STATION_STORAGE_KEY, value);
+  };
+
+  const handleProjectSelect = (e) => {
+    setProject(e.target.value);
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter') {
+      setSerial(e.target.value.trim());
+      e.target.value = '';
+    }
+  };
+
+  if (!station) {
+    return (
+      <div className="space-y-4">
+        <h2 className="text-brand-349 text-xl font-semibold">Select Station</h2>
+        <select
+          className="border border-gray-300 rounded-lg p-2"
+          value={station}
+          onChange={handleStationSelect}
+        >
+          <option value="">Choose…</option>
+          {Object.entries(PRODUCTION_STATIONS).map(([key, label]) => (
+            <option key={key} value={label}>
+              {label}
+            </option>
+          ))}
+        </select>
+      </div>
+    );
+  }
+
+  if (!project) {
+    return (
+      <div className="space-y-4">
+        <h2 className="text-brand-349 text-xl font-semibold">Select Project</h2>
+        <select
+          className="border border-gray-300 rounded-lg p-2"
+          value={project}
+          onChange={handleProjectSelect}
+        >
+          <option value="">Choose…</option>
+          {sampleProjects.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-brand-349 text-xl font-semibold">Scan Item</h2>
+      <input
+        ref={inputRef}
+        onKeyDown={handleKeyDown}
+        className="border border-gray-300 rounded-lg p-2 w-0 h-0 opacity-0"
+        aria-hidden
+      />
+      {serial && (
+        <div className="p-4 border rounded-lg bg-gray-50">
+          <div>Project: {project}</div>
+          <div>Serial: {serial}</div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add production worker role and storage constants
- allow bypass login for `pworker`
- add worker layout and page with basic station, project and barcode workflow
- redirect pworker home and expose worker route
- surface worker navigation in topbar/sidebar

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6889edd7a9a88321aaac06cb00ea87e7