### PR TITLE
Improve worker navigation

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Home, Activity, Package, Shield, CheckCircle, Wrench, BarChart3 } from 'lucide-react';
 import { cn, focusRing } from '../utils/cn';
 import { useSidebarContext } from '../hooks/sidebar/useSidebarContext';
+import { STATION_STORAGE_KEY } from '../constants';
 
 /**
  * Sidebar Component - Desktop only navigation
@@ -33,8 +34,13 @@ const Sidebar = ({
     };
 
     // Handle navigation
-    const handleNavigate = (path) => {
-        onNavigate(path);
+    const handleNavigate = (item) => {
+        if (item.station) {
+            localStorage.setItem(STATION_STORAGE_KEY, item.station);
+            onNavigate(`${item.path}?station=${encodeURIComponent(item.station)}`);
+            return;
+        }
+        onNavigate(item.path);
     };
 
     return (
@@ -53,13 +59,15 @@ const Sidebar = ({
             <nav className="p-4 space-y-2 flex-1 overflow-y-auto">
                 {navigationItems.map((item) => {
                     const Icon = iconMap[item.icon] || Home;
-                    const isActive = currentPath === item.path ||
-                        (item.path !== '/' && currentPath.startsWith(item.path + '/'));
+                    const currentStation = localStorage.getItem(STATION_STORAGE_KEY);
+                    const isActive = (currentPath === item.path ||
+                        (item.path !== '/' && currentPath.startsWith(item.path + '/')))
+                        && (!item.station || item.station === currentStation);
 
                     return (
                         <button
-                            key={item.path}
-                            onClick={() => handleNavigate(item.path)}
+                            key={item.id || item.path}
+                            onClick={() => handleNavigate(item)}
                             className={cn(
                                 'w-full flex items-center gap-3 px-4 py-3 rounded-lg text-left',
                                 'transition-all duration-200 group relative',

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -17,7 +17,7 @@ import {
 
 import Logo, { LogoVariants } from './Logo';
 import { cn, focusRing } from '../utils/cn';
-import { ROUTES, USER_ROLES } from '../constants';
+import { ROUTES, USER_ROLES, STATION_STORAGE_KEY } from '../constants';
 import { useTopbarContext } from '../hooks/topbar/useTopbarContext';
 import { useAuth } from '../auth/useAuth';
 
@@ -112,7 +112,14 @@ const TopBar = ({
     };
 
     // Handle navigation
-    const handleNavigate = (path) => {
+    const handleNavigate = (itemOrPath) => {
+        const path = typeof itemOrPath === 'string' ? itemOrPath : itemOrPath.path;
+        if (typeof itemOrPath === 'object' && itemOrPath.station) {
+            localStorage.setItem(STATION_STORAGE_KEY, itemOrPath.station);
+            onNavigate(`${path}?station=${encodeURIComponent(itemOrPath.station)}`);
+            setShowMobileMenu(false);
+            return;
+        }
         onNavigate(path);
         setShowMobileMenu(false);
     };
@@ -167,13 +174,15 @@ const TopBar = ({
                             <div className="absolute top-12 left-0 bg-white rounded-xl shadow-xl border border-gray-200 min-w-48 py-2 z-50">
                                 {mobileNavItems.map((item) => {
                                     const Icon = item.icon;
-                                    const isActive = currentPath === item.path ||
-                                        (item.path !== '/' && currentPath.startsWith(item.path + '/'));
+                                    const currentStation = localStorage.getItem(STATION_STORAGE_KEY);
+                                    const isActive = (currentPath === item.path ||
+                                        (item.path !== '/' && currentPath.startsWith(item.path + '/')))
+                                        && (!item.station || item.station === currentStation);
 
                                     return (
                                         <button
-                                            key={item.path}
-                                            onClick={() => handleNavigate(item.path)}
+                                            key={item.station || item.path}
+                                            onClick={() => handleNavigate(item)}
                                             className={cn(
                                                 'w-full flex items-center gap-3 px-4 py-3 text-left transition-colors',
                                                 isActive

--- a/src/hooks/sidebar/useSidebar.js
+++ b/src/hooks/sidebar/useSidebar.js
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useAuth } from '../../auth/useAuth';
+import { PRODUCTION_STATIONS } from '../../constants';
 
 /**
  * useSidebar Hook - Manages sidebar state and responsive behavior
@@ -82,7 +83,7 @@ export const useSidebar = ({
         path: '/',
         icon: 'Home',
         roles: ['admin', 'manager', 'operator', 'viewer'],
-        badge: null
+        badge: null,
       },
       {
         id: 'production',
@@ -90,7 +91,7 @@ export const useSidebar = ({
         path: '/production',
         icon: 'Activity',
         roles: ['admin', 'manager', 'operator'],
-        badge: 'Live'
+        badge: 'Live',
       },
       {
         id: 'inventory',
@@ -98,15 +99,7 @@ export const useSidebar = ({
         path: '/inventory',
         icon: 'Package',
         roles: ['admin', 'manager', 'operator'],
-        badge: null
-      },
-      {
-        id: 'worker',
-        label: 'Worker',
-        path: '/worker',
-        icon: 'Activity',
-        roles: ['pworker'],
-        badge: null
+        badge: null,
       },
       {
         id: 'quality',
@@ -114,7 +107,7 @@ export const useSidebar = ({
         path: '/quality',
         icon: 'CheckCircle',
         roles: ['admin', 'manager', 'operator'],
-        badge: null
+        badge: null,
       },
       {
         id: 'maintenance',
@@ -142,8 +135,21 @@ export const useSidebar = ({
       }
     ];
 
-    // Filter items based on user role
-    return user ? baseItems.filter(item => item.roles.includes(user.role)) : [];
+    if (!user) return [];
+
+    if (user.role === 'pworker') {
+      return Object.entries(PRODUCTION_STATIONS).map(([key, label]) => ({
+        id: `station-${key.toLowerCase()}`,
+        label,
+        path: '/worker',
+        icon: 'Activity',
+        roles: ['pworker'],
+        station: label,
+        badge: null,
+      }));
+    }
+
+    return baseItems.filter((item) => item.roles.includes(user.role));
   }, [user]);
 
   // Control functions

--- a/src/hooks/topbar/useTopbar.js
+++ b/src/hooks/topbar/useTopbar.js
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react';
 import { Home, Activity, Package, Shield } from 'lucide-react';
 import { useAuth } from '../../auth/useAuth';
+import { PRODUCTION_STATIONS } from '../../constants';
 
 export const useTopbar = () => {
   const { user } = useAuth();
@@ -21,10 +22,23 @@ export const useTopbar = () => {
       { icon: Home, label: 'Dashboard', path: '/', roles: ['admin', 'manager', 'operator', 'viewer'] },
       { icon: Activity, label: 'Production', path: '/production', badge: 'Live', roles: ['admin', 'manager', 'operator'] },
       { icon: Package, label: 'Inventory', path: '/inventory', roles: ['admin', 'manager', 'operator'] },
-      { icon: Activity, label: 'Worker', path: '/worker', roles: ['pworker'] },
       { icon: Shield, label: 'User Management', path: '/admin/users', roles: ['admin'] }
     ];
-    return user ? items.filter(item => item.roles.includes(user.role)) : [];
+
+    if (!user) return [];
+
+    if (user.role === 'pworker') {
+      return Object.entries(PRODUCTION_STATIONS).map(([key, label]) => ({
+        id: `station-${key.toLowerCase()}`,
+        icon: Activity,
+        label,
+        path: '/worker',
+        roles: ['pworker'],
+        station: label,
+      }));
+    }
+
+    return items.filter(item => item.roles.includes(user.role));
   }, [user]);
 
   const unreadNotificationsCount = useMemo(

--- a/src/layouts/WorkerLayout.jsx
+++ b/src/layouts/WorkerLayout.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import TopBar from '../components/TopBar';
+import Sidebar from '../components/Sidebar';
 import { cn } from '../utils/cn';
+import { SidebarProvider } from '../hooks/sidebar/SidebarProvider';
 import { TopbarProvider } from '../hooks/topbar/TopbarProvider';
 import { useAuth } from '../auth/useAuth';
 import { useNavigate, useLocation } from 'react-router-dom';
@@ -19,14 +21,24 @@ const WorkerLayout = ({ children, className = '', ...props }) => {
   return (
     <div className={cn('min-h-screen bg-gray-50', className)} {...props}>
       <TopbarProvider>
-        <TopBar
-          onLogout={handleLogout}
-          onNavigate={handleNavigate}
-          currentPath={pathname}
-        />
-        <main className="pt-[73px]">
-          <div className="p-6 max-w-4xl mx-auto">{children}</div>
-        </main>
+        <SidebarProvider>
+          <TopBar
+            onLogout={handleLogout}
+            onNavigate={handleNavigate}
+            currentPath={pathname}
+          />
+          <Sidebar onNavigate={handleNavigate} currentPath={pathname} />
+
+          <main
+            className={cn(
+              'transition-all duration-300',
+              'min-h-[calc(100vh-73px)]',
+              'lg:ml-64'
+            )}
+          >
+            <div className="p-6 max-w-4xl mx-auto">{children}</div>
+          </main>
+        </SidebarProvider>
       </TopbarProvider>
     </div>
   );

--- a/src/pages/ProductionWorker/WorkerPage.jsx
+++ b/src/pages/ProductionWorker/WorkerPage.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { PRODUCTION_STATIONS, STATION_STORAGE_KEY } from '../../constants';
+import { STATION_STORAGE_KEY } from '../../constants';
 import {
   sampleProjects,
   itemStatus,
@@ -8,8 +8,10 @@ import {
 import * as Select from '@radix-ui/react-select';
 import * as Checkbox from '@radix-ui/react-checkbox';
 import { ChevronDown, Check } from 'lucide-react';
+import { useSearchParams } from 'react-router-dom';
 
 export default function WorkerPage() {
+  const [searchParams] = useSearchParams();
   const [station, setStation] = useState(
     () => localStorage.getItem(STATION_STORAGE_KEY) || ''
   );
@@ -25,11 +27,14 @@ export default function WorkerPage() {
     }
   }, [project]);
 
-  const handleStationSelect = (e) => {
-    const value = e.target.value;
-    setStation(value);
-    localStorage.setItem(STATION_STORAGE_KEY, value);
-  };
+  useEffect(() => {
+    const param = searchParams.get('station');
+    if (param) {
+      setStation(param);
+      localStorage.setItem(STATION_STORAGE_KEY, param);
+    }
+  }, [searchParams]);
+
 
   const handleProjectSelect = (e) => {
     setProject(e.target.value);
@@ -48,30 +53,7 @@ export default function WorkerPage() {
     return (
       <div className="space-y-4">
         <h2 className="text-brand-349 text-xl font-semibold">Select Station</h2>
-        <Select.Root value={station} onValueChange={handleStationSelect}>
-          <Select.Trigger className="inline-flex items-center justify-between border border-gray-300 rounded-lg px-3 py-2 w-60">
-            <Select.Value placeholder="Choose…" />
-            <Select.Icon asChild>
-              <ChevronDown size={16} />
-            </Select.Icon>
-          </Select.Trigger>
-          <Select.Portal>
-            <Select.Content className="bg-white shadow rounded-md border p-1">
-              {Object.entries(PRODUCTION_STATIONS).map(([key, label]) => (
-                <Select.Item
-                  key={key}
-                  value={label}
-                  className="px-3 py-1.5 rounded-md flex items-center gap-2 text-sm hover:bg-gray-100 cursor-pointer"
-                >
-                  <Select.ItemText>{label}</Select.ItemText>
-                  <Select.ItemIndicator className="ml-auto">
-                    <Check size={14} />
-                  </Select.ItemIndicator>
-                </Select.Item>
-              ))}
-            </Select.Content>
-          </Select.Portal>
-        </Select.Root>
+        <p>Select a station from the sidebar to begin.</p>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- add sidebar to WorkerLayout
- allow station selection via sidebar or mobile nav
- store station in localStorage and URL query
- update WorkerPage to read station from URL

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688a2627fd4483218276b8e4b0ebfe61