### PR TITLE
Update authentication flow for new backend

### DIFF
--- a/src/api/users.js
+++ b/src/api/users.js
@@ -1,5 +1,5 @@
 
-import { API_ENDPOINTS, AUTH_STORAGE_KEYS } from '../constants';
+import { API_ENDPOINTS } from '../constants';
 
 
 const BASE_URL = API_ENDPOINTS.BASE_URL;
@@ -7,9 +7,6 @@ const BASE_URL = API_ENDPOINTS.BASE_URL;
 async function request(path, options = {}) {
   const headers = { 'Content-Type': 'application/json', ...(options.headers || {}) };
 
-  const token = localStorage.getItem(AUTH_STORAGE_KEYS.TOKEN);
-
-  if (token) headers['Authorization'] = `Bearer ${token}`;
 
   const res = await fetch(`${BASE_URL}${path}`, {
     credentials: 'include',

--- a/src/auth/AuthProvider.jsx
+++ b/src/auth/AuthProvider.jsx
@@ -96,17 +96,13 @@ export const AuthProvider = ({ children }) => {
     }
 
     try {
-      const { token, user: loggedIn } = await api.post(
+      const { user: loggedIn } = await api.post(
         API_ENDPOINTS.AUTH.LOGIN,
         {
           username,
           password,
         },
       );
-
-      if (token) {
-        localStorage.setItem(AUTH_STORAGE_KEYS.TOKEN, token);
-      }
 
       setUser(loggedIn);
     } finally {
@@ -128,7 +124,6 @@ export const AuthProvider = ({ children }) => {
     try {
       await api.post(API_ENDPOINTS.AUTH.LOGOUT);
     } finally {
-      localStorage.removeItem(AUTH_STORAGE_KEYS.TOKEN);
       setUser(null);
     }
   };

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -328,7 +328,7 @@ export const PRIORITY_LEVELS = {
 // =====================================================
 
 export const API_ENDPOINTS = {
-  BASE_URL: import.meta.env.VITE_API_URL || 'http://localhost:5000/api',
+  BASE_URL: import.meta.env.VITE_API_URL || 'http://192.168.10.15:5000/api',
 
   // Authentication
   AUTH: {


### PR DESCRIPTION
## Summary
- point API base URL to new backend
- simplify auth token handling for session-based login

## Testing
- `npm run lint`
- `npm run build` *(fails: sampleProjects not exported)*

------
https://chatgpt.com/codex/tasks/task_e_688b635ef4988321ba912ca3f03f9a98