### PR TITLE
Add admin user management UI

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,7 +26,7 @@ export default function App() {
 
             {/* Admin‑only subsection */}
             <Route element={<ProtectedRoute roles={["admin"]} />}>
-              <Route path="admin" element={<UsersPage />} />
+              <Route path="admin/users" element={<UsersPage />} />
             </Route>
           </Route>
           <Route element={<ProtectedRoute roles={["pworker"]} />}> 

--- a/src/auth/AuthProvider.jsx
+++ b/src/auth/AuthProvider.jsx
@@ -128,7 +128,28 @@ export const AuthProvider = ({ children }) => {
     }
   };
 
-  const value = { user, loading, login, logout };
+  // ------------------------------------------------------------------
+  // Refresh user from API
+  // ------------------------------------------------------------------
+  const refreshUser = async () => {
+    setLoading(true);
+
+    if (FEATURES.AUTH_BYPASS) {
+      const stored = loadBypassUser();
+      setUser(stored);
+      setLoading(false);
+      return;
+    }
+
+    try {
+      const data = await api.get(API_ENDPOINTS.AUTH.CURRENT_USER);
+      setUser(data);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const value = { user, loading, login, logout, refreshUser, setUser };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -12,14 +12,16 @@ import {
     X,
     Home,
     Activity,
-    Package
+    Package,
+    RefreshCcw
 } from 'lucide-react';
 
 import Logo, { LogoVariants } from './Logo';
 import { cn, focusRing } from '../utils/cn';
-import { ROUTES, USER_ROLES, STATION_STORAGE_KEY } from '../constants';
+import { ROUTES, USER_ROLES, STATION_STORAGE_KEY, API_ENDPOINTS } from '../constants';
 import { useTopbarContext } from '../hooks/topbar/useTopbarContext';
 import { useAuth } from '../auth/useAuth';
+import api from '../api/users';
 
 /**
  * TopBar Component - Header with mobile navigation dropdown
@@ -41,7 +43,7 @@ const TopBar = ({
     ...props
 }) => {
 
-    const { user } = useAuth();
+    const { user, refreshUser } = useAuth();
 
     const {
         showUserDropdown,
@@ -99,6 +101,18 @@ const TopBar = ({
             onNavigate(ROUTES.LOGIN);
         } catch (error) {
             console.error('Logout failed:', error);
+        }
+    };
+
+    // Stop impersonation and return to admin view
+    const handleStopImpersonation = async () => {
+        try {
+            await api.post(API_ENDPOINTS.ADMIN.STOP_IMPERSONATION);
+            await refreshUser();
+            setShowUserDropdown(false);
+            onNavigate(ROUTES.ADMIN_USERS);
+        } catch (error) {
+            console.error('Stop impersonation failed:', error);
         }
     };
 
@@ -421,9 +435,19 @@ const TopBar = ({
                                         }}
                                         className="flex items-center gap-3 px-4 py-2 text-gray-700 hover:bg-gray-50 transition-colors w-full text-left"
                                     >
-                                        <HelpCircle size={16} />
+                                    <HelpCircle size={16} />
                                         Help & Support
                                     </button>
+
+                                    {user?.role !== USER_ROLES.ADMIN && (
+                                        <button
+                                            onClick={handleStopImpersonation}
+                                            className="flex items-center gap-3 px-4 py-2 text-gray-700 hover:bg-gray-50 transition-colors w-full text-left"
+                                        >
+                                            <RefreshCcw size={16} />
+                                            Return to Admin
+                                        </button>
+                                    )}
                                 </div>
 
                                 {/* Logout */}

--- a/src/pages/admin/UsersPage.jsx
+++ b/src/pages/admin/UsersPage.jsx
@@ -1,9 +1,183 @@
-import React from "react";
+import React, { useEffect, useState } from 'react';
+import { Table, Button } from '@radix-ui/themes';
+import * as Dialog from '@radix-ui/react-dialog';
+import api from '../../api/users';
+import { API_ENDPOINTS } from '../../constants';
+import { useAuth } from '../../auth/useAuth';
+
 export default function UsersPage() {
-    return (
-        <div className="p-6">
-            <h2 className="text-brand-349 text-xl font-semibold mb-2">User Management</h2>
-            <p>Admin user list placeholder.</p>
-        </div>
-    );
+  const { refreshUser } = useAuth();
+  const [users, setUsers] = useState([]);
+  const [open, setOpen] = useState(false);
+  const [editing, setEditing] = useState(null);
+  const [form, setForm] = useState({
+    username: '',
+    password: '',
+    role: 'worker',
+    station: '',
+    full_name: '',
+    email: '',
+  });
+
+  const loadUsers = async () => {
+    try {
+      const data = await api.get(API_ENDPOINTS.ADMIN.USERS);
+      setUsers(data.users || []);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  useEffect(() => {
+    loadUsers();
+  }, []);
+
+  const openNew = () => {
+    setEditing(null);
+    setForm({ username: '', password: '', role: 'worker', station: '', full_name: '', email: '' });
+    setOpen(true);
+  };
+
+  const openEdit = (u) => {
+    setEditing(u.id);
+    setForm({ ...u, password: '' });
+    setOpen(true);
+  };
+
+  const save = async () => {
+    try {
+      if (editing) {
+        await api.put(API_ENDPOINTS.ADMIN.USER(editing), form);
+      } else {
+        await api.post(API_ENDPOINTS.ADMIN.USERS, form);
+      }
+      setOpen(false);
+      await loadUsers();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const deleteUser = async (id) => {
+    if (!window.confirm('Delete user?')) return;
+    try {
+      await api.delete(API_ENDPOINTS.ADMIN.USER(id));
+      await loadUsers();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const impersonate = async (id) => {
+    try {
+      await api.post(API_ENDPOINTS.ADMIN.IMPERSONATE(id));
+      await refreshUser();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-brand-349 text-xl font-semibold">User Management</h2>
+        <Button onClick={openNew}>New User</Button>
+      </div>
+
+      <Table.Root>
+        <Table.Header>
+          <Table.Row>
+            <Table.ColumnHeaderCell>Username</Table.ColumnHeaderCell>
+            <Table.ColumnHeaderCell>Role</Table.ColumnHeaderCell>
+            <Table.ColumnHeaderCell>Station</Table.ColumnHeaderCell>
+            <Table.ColumnHeaderCell>Email</Table.ColumnHeaderCell>
+            <Table.ColumnHeaderCell></Table.ColumnHeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {users.map((u) => (
+            <Table.Row key={u.id}>
+              <Table.Cell>{u.username}</Table.Cell>
+              <Table.Cell className="capitalize">{u.role}</Table.Cell>
+              <Table.Cell>{u.station || '-'}</Table.Cell>
+              <Table.Cell>{u.email}</Table.Cell>
+              <Table.Cell>
+                <div className="flex gap-2">
+                  <Button size="1" variant="soft" onClick={() => openEdit(u)}>
+                    Edit
+                  </Button>
+                  <Button size="1" variant="soft" onClick={() => impersonate(u.id)}>
+                    Impersonate
+                  </Button>
+                  <Button size="1" color="red" variant="soft" onClick={() => deleteUser(u.id)}>
+                    Delete
+                  </Button>
+                </div>
+              </Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table.Root>
+
+      <Dialog.Root open={open} onOpenChange={setOpen}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 bg-black/50" />
+          <Dialog.Content className="fixed p-4 bg-white shadow rounded-md top-[50%] left-1/2 -translate-x-1/2 -translate-y-1/2 space-y-3 w-80">
+            <Dialog.Title className="text-lg font-medium">
+              {editing ? 'Edit User' : 'New User'}
+            </Dialog.Title>
+            <div className="space-y-2">
+              <input
+                className="w-full border rounded px-2 py-1 text-sm"
+                placeholder="Username"
+                value={form.username}
+                onChange={(e) => setForm({ ...form, username: e.target.value })}
+              />
+              {!editing && (
+                <input
+                  type="password"
+                  className="w-full border rounded px-2 py-1 text-sm"
+                  placeholder="Password"
+                  value={form.password}
+                  onChange={(e) => setForm({ ...form, password: e.target.value })}
+                />
+              )}
+              <input
+                className="w-full border rounded px-2 py-1 text-sm"
+                placeholder="Full name"
+                value={form.full_name}
+                onChange={(e) => setForm({ ...form, full_name: e.target.value })}
+              />
+              <input
+                className="w-full border rounded px-2 py-1 text-sm"
+                placeholder="Email"
+                value={form.email}
+                onChange={(e) => setForm({ ...form, email: e.target.value })}
+              />
+              <select
+                className="w-full border rounded px-2 py-1 text-sm"
+                value={form.role}
+                onChange={(e) => setForm({ ...form, role: e.target.value })}
+              >
+                <option value="admin">admin</option>
+                <option value="worker">worker</option>
+              </select>
+              <input
+                className="w-full border rounded px-2 py-1 text-sm"
+                placeholder="Station"
+                value={form.station || ''}
+                onChange={(e) => setForm({ ...form, station: e.target.value })}
+              />
+            </div>
+            <div className="flex justify-end gap-2 pt-2">
+              <Button variant="soft" onClick={() => setOpen(false)}>
+                Cancel
+              </Button>
+              <Button onClick={save}>Save</Button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- expose `refreshUser` helper in auth provider
- create admin User Management panel using Radix UI
- allow impersonation and return to admin
- expose stop‐impersonation option in top bar
- adjust admin routes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688b6bd123a48321a744b93dac3dcb1f